### PR TITLE
Ejercicio 13

### DIFF
--- a/Ejercicio13/Ejercicio13.pde
+++ b/Ejercicio13/Ejercicio13.pde
@@ -1,0 +1,37 @@
+PVector fuenteLuz;
+PVector normalSuperficie;
+
+void setup() {
+  size(400, 400);
+  fuenteLuz = new PVector(100, 200); // Posición de la fuente de luz
+  normalSuperficie = new PVector(1, -1); // Vector normal a la superficie de reflexión
+  normalSuperficie.normalize(); // Normalizamos el vector normal
+}
+
+void draw() {
+  background(255);
+  
+  // Dibujar la fuente de luz
+  fill(255, 255, 0);
+  ellipse(fuenteLuz.x, fuenteLuz.y, 10, 10);
+  
+  // Dibujar la superficie de reflexión
+  stroke(0);
+  line(200, 400, 300, 200);
+  
+  // Calcular el vector de dirección del rayo de luz incidente
+  PVector rayoIncidente = new PVector(mouseX - fuenteLuz.x, mouseY - fuenteLuz.y);
+  rayoIncidente.normalize(); // Normalizamos el vector de dirección
+  
+  // Calcular el vector de dirección del rayo reflejado usando la fórmula de reflexión especular
+  float productoPunto = PVector.dot(rayoIncidente, normalSuperficie);
+  PVector rayoReflejado = PVector.sub(rayoIncidente, PVector.mult(normalSuperficie, 2 * productoPunto));
+  
+  // Dibujar el rayo incidente
+  stroke(255, 0, 0);
+  line(fuenteLuz.x, fuenteLuz.y, mouseX, mouseY);
+  
+  // Dibujar el rayo reflejado
+  stroke(0, 0, 255);
+  line(fuenteLuz.x, fuenteLuz.y, fuenteLuz.x + rayoReflejado.x * 100, fuenteLuz.y + rayoReflejado.y * 100);
+}


### PR DESCRIPTION
Cálculo del vector de dirección del rayo incidente: para este ejercicio el  rayo Incidente se calcula como un vector que apunta desde la fuente de luz hacia la posición del mouse y luego se normaliza para obtener una dirección unitaria. Cálculo del vector de dirección del rayo reflejado: El producto punto entre rayoIncidente y normalSuperficie se utiliza para determinar cuánto de la luz incidente se refleja en la dirección de la normal de la superficie. Luego, se utiliza la fórmula de reflexión especular para calcular el vector de dirección del rayo reflejado, restando el doble del producto punto de rayoIncidente y normalSuperficie de rayoIncidente